### PR TITLE
Removes the upstream-require script from root composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes specific to pantheon-upstreams/drupal-composer-managed are noted here.
 
+## Pantheon Update #4 - 2023-06-27
+
+### Changed
+
+- Removed the `upstream-require` script ([#17](https://github.com/pantheon-systems/drupal-composer-managed/pull/17), [#21](https://github.com/pantheon-systems/drupal-composer-managed/pull/21), [#28](https://github.com/pantheon-systems/drupal-composer-managed/pull/28)). This is now available as a standalone Composer plugin: [`pantheon-systems/upstream-management`](https://packagist.org/packages/pantheon-systems/upstream-management)
+- Fixed `composer update --dry-run` by setting the path repository version to `dev-main` ([#39](https://github.com/pantheon-systems/drupal-composer-managed/pull/39))
+
 
 ## Pantheon Update #3 - 2022-03-23
 

--- a/upstream-configuration/composer.json
+++ b/upstream-configuration/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "pantheon-upstreams/upstream-configuration",
     "type": "project",
+    "version": "dev-main",
     "repositories": [
         {
             "type": "composer",

--- a/upstream-configuration/scripts/ComposerScripts.php
+++ b/upstream-configuration/scripts/ComposerScripts.php
@@ -21,33 +21,8 @@ class ComposerScripts {
 
   /**
    * Prepare for Composer to update dependencies.
-   *
-   * Composer will attempt to guess the version to use when evaluating
-   * dependencies for path repositories. This has the undesirable effect
-   * of producing different results in the composer.lock file depending on
-   * which branch was active when the update was executed. This can lead to
-   * unnecessary changes, and potentially merge conflicts when working with
-   * path repositories on Pantheon multidevs.
-   *
-   * To work around this problem, it is possible to define an environment
-   * variable that contains the version to use whenever Composer would normally
-   * "guess" the version from the git repository branch. We set this invariantly
-   * to "dev-main" so that the composer.lock file will not change if the same
-   * update is later ran on a different branch.
-   *
-   * @see https://github.com/composer/composer/blob/main/doc/articles/troubleshooting.md#dependencies-on-the-root-package
    */
   public static function preUpdate(Event $event) {
-    $io = $event->getIO();
-
-    // We will only set the root version if it has not already been overriden
-    if (!getenv('COMPOSER_ROOT_VERSION')) {
-      // This is not an error; rather, we are writing to stderr.
-      $io->writeError("<info>Using version 'dev-main' for path repositories.</info>");
-
-      putenv('COMPOSER_ROOT_VERSION=dev-main');
-    }
-
     // Apply updates to top-level composer.json
     static::applyComposerJsonUpdates($event);
   }


### PR DESCRIPTION
| composer upstream-require is now available as a standalone package. Use composer require pantheon-systems/upstream-management to re-integrate this workflow for custom upstream dependency management. For more information, refer to the README in /upstream-configuration. Also fixed composer update --dry-run.